### PR TITLE
FTGP-4524: Make value nullable for KeyFigureData

### DIFF
--- a/Foretagsplatsen.Api/Entities/KeyFigureData.cs
+++ b/Foretagsplatsen.Api/Entities/KeyFigureData.cs
@@ -7,6 +7,6 @@
     {
         public string KeyFigureInfoId { get; set; }
         public Period Period { get; set; }
-        public decimal Value { get; set; }
+        public decimal? Value { get; set; }
     }
 }

--- a/Foretagsplatsen.Api2/Entities/KeyFigures/KeyFigureData.cs
+++ b/Foretagsplatsen.Api2/Entities/KeyFigures/KeyFigureData.cs
@@ -20,7 +20,7 @@ namespace Foretagsplatsen.Api2.Entities.KeyFigures
         /// </summary>
         public string keyFigureInfoId { get; set; }
         public Period period { get; set; }
-        public decimal value { get; set; }
+        public decimal? value { get; set; }
         public string dimensionId { get; set; }
     }
 }


### PR DESCRIPTION
That should tell the receiver that there is no data specified for that period. Previous behaviour was sending the default  value.
