### PR TITLE
28519377: Fix hint path for Newtonsoft.Json

### DIFF
--- a/Foretagsplatsen.Api2/Foretagsplatsen.Api2.csproj
+++ b/Foretagsplatsen.Api2/Foretagsplatsen.Api2.csproj
@@ -42,7 +42,7 @@
       <HintPath>..\ThirdParty\DevDefined\DevDefined.OAuth.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />


### PR DESCRIPTION
The last package upgrade broke build for mono/Rider.
Restoring the hint as it was before the upgrade.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/foretagsplatsen/foretagsplatsen-dotnet-api/41)
<!-- Reviewable:end -->
