### PR TITLE
FIN-1594: Add an agency field to the AgencyUser

### DIFF
--- a/Foretagsplatsen.Api2/Entities/User/AgencyUser.cs
+++ b/Foretagsplatsen.Api2/Entities/User/AgencyUser.cs
@@ -14,5 +14,10 @@ namespace Foretagsplatsen.Api2.Entities.User
         /// List of company ids.
         /// </summary>
         public IEnumerable<string> customers { get; set; }
+
+        /// <summary>
+        /// Agency id attached to the user
+        /// </summary>
+        public string agency { get; set; }
     }
 }


### PR DESCRIPTION
When creating an agency user from an agency director in Web.Api, we need to be sure the agency is the same for both users. Without this field, the POST request fails.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/foretagsplatsen/Foretagsplatsen-DotNet-API/43)
<!-- Reviewable:end -->
